### PR TITLE
Add configurable predictor attention modes

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -57,6 +57,7 @@ augmentations: !!python/object:mjepa.AugmentationConfig
 jepa: !!python/object:mjepa.JEPAConfig
   momentum: 0.98
   predictor_depth: 4
+  predictor_attention_mode: cross_attention
   disable_predictor_regularizers: false
   context_ratio: 0.5
   target_ratio: 0.25

--- a/mjepa/__init__.py
+++ b/mjepa/__init__.py
@@ -1,6 +1,6 @@
 import importlib.metadata
 
-from .jepa import CrossAttentionPredictor, JEPAConfig
+from .jepa import CrossAttentionPredictor, JEPAConfig, PredictorAttentionMode
 from .metrics import CLSPatchAlignmentMetric, SimilarityDistanceCouplingMetric
 from .optimizer import OptimizerConfig
 from .trainer import ResolutionConfig, TrainerConfig
@@ -10,6 +10,7 @@ __version__ = importlib.metadata.version("mjepa")
 __all__ = [
     "TrainerConfig",
     "JEPAConfig",
+    "PredictorAttentionMode",
     "OptimizerConfig",
     "CrossAttentionPredictor",
     "ResolutionConfig",

--- a/mjepa/jepa.py
+++ b/mjepa/jepa.py
@@ -28,6 +28,15 @@ MSE_JEPA_LOSS_KIND = "mse"
 COSINE_JEPA_LOSS_KIND = "cosine"
 JEPALossKind: TypeAlias = Literal["mse", "cosine"]
 JEPA_LOSS_KINDS: tuple[JEPALossKind, ...] = (MSE_JEPA_LOSS_KIND, COSINE_JEPA_LOSS_KIND)
+CROSS_ATTENTION_PREDICTOR_MODE = "cross_attention"
+DECODER_PREDICTOR_MODE = "decoder"
+ENCODER_PREDICTOR_MODE = "encoder"
+PredictorAttentionMode: TypeAlias = Literal["cross_attention", "decoder", "encoder"]
+PREDICTOR_ATTENTION_MODES: tuple[PredictorAttentionMode, ...] = (
+    CROSS_ATTENTION_PREDICTOR_MODE,
+    DECODER_PREDICTOR_MODE,
+    ENCODER_PREDICTOR_MODE,
+)
 
 
 def _normalize_dtype(dtype: torch.dtype | str | None, field_name: str) -> torch.dtype | None:
@@ -65,7 +74,7 @@ class CrossAttentionPredictor(nn.Module):
 
     The predictor consists of the following components:
         - Separate learnable position encodings for both context and target embeddings
-        - A series of cross-attention layers between the target queries and the context.
+        - A configurable series of predictor blocks operating in cross-attention, decoder, or encoder mode.
         - A linear projection head to create the final output.
 
     Args:
@@ -76,6 +85,9 @@ class CrossAttentionPredictor(nn.Module):
         device: Device to place the predictor on.
         disable_predictor_regularizers: Whether to force predictor stochastic depth, hidden dropout,
             and attention dropout to ``0.0``.
+        attention_mode: Predictor attention mode. ``"cross_attention"`` keeps the current behavior,
+            ``"decoder"`` adds self-attention over target queries before cross-attention, and
+            ``"encoder"`` runs self-attention over the concatenated query/context sequence.
     """
 
     def __init__(
@@ -85,17 +97,21 @@ class CrossAttentionPredictor(nn.Module):
         out_dim: int | None = None,
         device: torch.device | None = None,
         disable_predictor_regularizers: bool = False,
+        attention_mode: PredictorAttentionMode = CROSS_ATTENTION_PREDICTOR_MODE,
     ):
         super().__init__()
+        if attention_mode not in PREDICTOR_ATTENTION_MODES:
+            raise ValueError(f"attention_mode must be one of {list(PREDICTOR_ATTENTION_MODES)}")
         factory_kwargs = {"device": device, "dtype": backbone.config.dtype}
         self.hidden_size = backbone.config.hidden_size
         self.out_dim = out_dim or backbone.config.hidden_size
+        self.attention_mode = attention_mode
         spatial_size = backbone.stem.tokenized_size(backbone.config.img_size)
         self.pos_enc_target = LearnablePosition(backbone.config.hidden_size, spatial_size, **factory_kwargs)
         self.rope = backbone.rope
 
         # Predictor blocks and output projection
-        self.blocks = nn.ModuleList([self._create_block(backbone, device) for _ in range(depth)])
+        self.blocks = nn.ModuleList([self._create_block(backbone, device, attention_mode) for _ in range(depth)])
         if disable_predictor_regularizers:
             self._disable_predictor_regularizers()
 
@@ -107,8 +123,18 @@ class CrossAttentionPredictor(nn.Module):
         return self.predictor_proj.weight.dtype
 
     @staticmethod
-    def _create_block(backbone: ViT, device: torch.device | None) -> nn.Module:
-        return backbone.create_cross_attention_layer(device=device, dtype=backbone.config.dtype)
+    def _create_block(
+        backbone: ViT,
+        device: torch.device | None,
+        attention_mode: PredictorAttentionMode,
+    ) -> nn.Module:
+        if attention_mode == CROSS_ATTENTION_PREDICTOR_MODE:
+            return backbone.create_cross_attention_layer(device=device, dtype=backbone.config.dtype)
+        if attention_mode == DECODER_PREDICTOR_MODE:
+            return backbone.create_decoder_layer(device=device, dtype=backbone.config.dtype)
+        if attention_mode == ENCODER_PREDICTOR_MODE:
+            return backbone.create_encoder_layer(device=device, dtype=backbone.config.dtype)
+        raise ValueError(f"Unsupported predictor attention mode: {attention_mode!r}")
 
     @staticmethod
     def _reset_projection_parameters(projection: nn.Linear) -> None:
@@ -145,11 +171,57 @@ class CrossAttentionPredictor(nn.Module):
         # Force predictor regularizers to zero without changing the backbone configuration.
         no_regularization = 0.0
         for block in self.blocks:
-            block = cast(Any, block)
-            block.drop_path_rate = no_regularization
-            block.cross_attention.dropout.p = no_regularization
-            block.cross_attention.attention_dropout.p = no_regularization
-            block.mlp.dropout.p = no_regularization
+            typed_block = cast(Any, block)
+            typed_block.drop_path_rate = no_regularization
+            for attention in self._attention_modules(block):
+                attention.dropout.p = no_regularization
+                attention.attention_dropout.p = no_regularization
+            typed_block.mlp.dropout.p = no_regularization
+
+    @staticmethod
+    def _attention_modules(block: nn.Module) -> tuple[Any, ...]:
+        typed_block = cast(Any, block)
+        return tuple(
+            attention
+            for attention_name in ("self_attention", "cross_attention")
+            if (attention := getattr(typed_block, attention_name, None)) is not None
+        )
+
+    @staticmethod
+    def _prepare_encoder_inputs(
+        query: Tensor,
+        context: Tensor,
+        rope_q: Tensor | None,
+        rope_k: Tensor | None,
+    ) -> tuple[Tensor, Tensor | None, int]:
+        query_length = query.shape[1]
+        combined = torch.cat([query, context], dim=1)
+        if rope_q is None or rope_k is None:
+            return combined, None, query_length
+        return combined, torch.cat([rope_q, rope_k], dim=3), query_length
+
+    def _forward_encoder_blocks(
+        self,
+        query: Tensor,
+        context: Tensor,
+        rope_q: Tensor | None,
+        rope_k: Tensor | None,
+    ) -> Tensor:
+        combined, combined_rope, query_length = self._prepare_encoder_inputs(query, context, rope_q, rope_k)
+        for block in self.blocks:
+            combined = cast(Any, block)(combined, rope=combined_rope)
+        return combined[:, :query_length]
+
+    def _forward_cross_or_decoder_blocks(
+        self,
+        query: Tensor,
+        context: Tensor,
+        rope_q: Tensor | None,
+        rope_k: Tensor | None,
+    ) -> Tensor:
+        for block in self.blocks:
+            query = cast(Any, block)(query, context, rope_q=rope_q, rope_k=rope_k)
+        return query
 
     def forward_features(
         self,
@@ -170,10 +242,9 @@ class CrossAttentionPredictor(nn.Module):
             rope_q, rope_k = self.prepare_rope(tokenized_size, context_mask, target_mask, rope_seed=rope_seed)
 
             # Run query and context through predictor
-            for block in self.blocks:
-                query = block(query, context, rope_q=rope_q, rope_k=rope_k)
-
-            return query
+            if self.attention_mode == ENCODER_PREDICTOR_MODE:
+                return self._forward_encoder_blocks(query, context, rope_q, rope_k)
+            return self._forward_cross_or_decoder_blocks(query, context, rope_q, rope_k)
 
     def forward_heads(
         self,
@@ -551,6 +622,7 @@ class JEPAConfig:
             from this value to 1.0 over the course of training if scheduled is ``True``.
         scheduled: Whether to schedule the momentum.
         predictor_depth: Depth of the predictor network.
+        predictor_attention_mode: Predictor block attention mode.
         disable_predictor_regularizers: Whether to force predictor stochastic depth, hidden dropout,
             and attention dropout to ``0.0``.
         teacher_dtype: Optional dtype override for the teacher and Gram teacher weights.
@@ -573,6 +645,7 @@ class JEPAConfig:
     momentum: float = 0.99
     scheduled: bool = False
     predictor_depth: int = 4
+    predictor_attention_mode: PredictorAttentionMode = CROSS_ATTENTION_PREDICTOR_MODE
     disable_predictor_regularizers: bool = False
     teacher_dtype: torch.dtype | str | None = None
     use_gram_anchoring: bool = False
@@ -592,6 +665,8 @@ class JEPAConfig:
             raise ValueError("context_ratio must be in the range (0, 1]")
         if not 0 < self.target_ratio <= 1:
             raise ValueError("target_ratio must be in the range (0, 1]")
+        if self.predictor_attention_mode not in PREDICTOR_ATTENTION_MODES:
+            raise ValueError(f"predictor_attention_mode must be one of {list(PREDICTOR_ATTENTION_MODES)}")
         if self.use_gram_anchoring and self.gram_start_epoch is None:
             raise ValueError("gram_start_epoch must be set when use_gram_anchoring is enabled")
         if self.gram_teacher_epoch <= 0:

--- a/mjepa/jepa.py
+++ b/mjepa/jepa.py
@@ -188,6 +188,17 @@ class CrossAttentionPredictor(nn.Module):
         )
 
     @staticmethod
+    def _append_identity_rope(rope: Tensor, suffix_length: int) -> Tensor:
+        if suffix_length == 0:
+            return rope
+
+        sin, cos = rope
+        suffix_shape = (*sin.shape[:-2], suffix_length, sin.shape[-1])
+        sin_suffix = sin.new_zeros(suffix_shape)
+        cos_suffix = cos.new_ones(suffix_shape)
+        return torch.stack([torch.cat([sin, sin_suffix], dim=-2), torch.cat([cos, cos_suffix], dim=-2)], dim=0)
+
+    @staticmethod
     def _prepare_encoder_inputs(
         query: Tensor,
         context: Tensor,
@@ -196,8 +207,10 @@ class CrossAttentionPredictor(nn.Module):
     ) -> tuple[Tensor, Tensor | None, int]:
         query_length = query.shape[1]
         combined = torch.cat([query, context], dim=1)
-        if rope_q is None or rope_k is None:
+        if rope_q is None:
             return combined, None, query_length
+        if rope_k is None:
+            return combined, CrossAttentionPredictor._append_identity_rope(rope_q, context.shape[1]), query_length
         return combined, torch.cat([rope_q, rope_k], dim=3), query_length
 
     def _forward_encoder_blocks(

--- a/mjepa/model.py
+++ b/mjepa/model.py
@@ -75,6 +75,11 @@ class MJEPA(nn.Module):
         self.config = config
         self.student = backbone
         teacher_dtype = config.teacher_dtype
+        if predictor.attention_mode != config.predictor_attention_mode:
+            raise ValueError(
+                "Predictor attention mode does not match JEPAConfig: "
+                f"{predictor.attention_mode!r} != {config.predictor_attention_mode!r}"
+            )
         self.teacher = setup_teacher(backbone, dtype=teacher_dtype)
         self.predictor = predictor
         if self._use_stem_targets():

--- a/mjepa/trainer.py
+++ b/mjepa/trainer.py
@@ -21,7 +21,13 @@ from tqdm import tqdm
 from vit import ViT
 from vit.pos_enc import LearnablePosition
 
-from .jepa import CrossAttentionPredictor
+from .jepa import (
+    CROSS_ATTENTION_PREDICTOR_MODE,
+    DECODER_PREDICTOR_MODE,
+    ENCODER_PREDICTOR_MODE,
+    CrossAttentionPredictor,
+    PredictorAttentionMode,
+)
 from .optimizer import (
     OptimizerLike,
     SchedulerLike,
@@ -256,6 +262,27 @@ def _predictor_shallow_head_mismatch(predictor: CrossAttentionPredictor, predict
     return (predictor.predictor_proj_shallow is not None) != _predictor_checkpoint_has_shallow_head(predictor_state)
 
 
+def _infer_predictor_checkpoint_attention_mode(
+    predictor_state: Mapping[str, Any],
+) -> PredictorAttentionMode | None:
+    has_self_attention = any(".self_attention." in key for key in predictor_state)
+    has_cross_attention = any(".cross_attention." in key for key in predictor_state)
+    if has_self_attention and has_cross_attention:
+        return DECODER_PREDICTOR_MODE
+    if has_self_attention:
+        return ENCODER_PREDICTOR_MODE
+    if has_cross_attention:
+        return CROSS_ATTENTION_PREDICTOR_MODE
+    return None
+
+
+def _predictor_attention_mode_mismatch(
+    predictor: CrossAttentionPredictor,
+    checkpoint_mode: PredictorAttentionMode | None,
+) -> bool:
+    return checkpoint_mode is not None and predictor.attention_mode != checkpoint_mode
+
+
 def load_checkpoint(
     path: os.PathLike,
     backbone: ViT,
@@ -294,11 +321,22 @@ def load_checkpoint(
     new_tokenized_size = backbone.stem.tokenized_size(backbone.config.img_size)
     step = int(data["step"])
     epoch = int(data["epoch"])
+    predictor_checkpoint_mode = (
+        _infer_predictor_checkpoint_attention_mode(data["predictor"])
+        if predictor is not None and data["predictor"] is not None
+        else None
+    )
 
     if mode == "resume" and predictor and _predictor_shallow_head_mismatch(predictor, data["predictor"]):
         raise ValueError(
             "Cannot resume across predictor shallow-head configuration changes; "
             "load with mode='fresh' or match stem-target settings."
+        )
+    if mode == "resume" and predictor and _predictor_attention_mode_mismatch(predictor, predictor_checkpoint_mode):
+        raise ValueError(
+            "Cannot resume across predictor attention-mode changes; "
+            f"checkpoint uses {predictor_checkpoint_mode!r} but current predictor uses {predictor.attention_mode!r}. "
+            "Load with mode='fresh' or match predictor_attention_mode."
         )
 
     # Validate image size

--- a/tests/test_jepa.py
+++ b/tests/test_jepa.py
@@ -665,6 +665,26 @@ class TestCrossAttentionPredictor:
         assert output.shape == (2, 16, 64)
         assert output.dtype == torch.float32
 
+    def test_encoder_mode_preserves_target_rope_without_context_mask(self):
+        """Test encoder mode keeps target-token RoPE and uses identity RoPE for non-spatial context."""
+        query = torch.randn(2, 16, 64)
+        cls_context = torch.randn(2, 4, 64)
+        rope_q = torch.randn(2, 2, 1, 16, 8)
+
+        combined, combined_rope, query_length = CrossAttentionPredictor._prepare_encoder_inputs(
+            query,
+            cls_context,
+            rope_q,
+            rope_k=None,
+        )
+
+        assert combined.shape == (2, 20, 64)
+        assert query_length == 16
+        assert combined_rope is not None
+        assert torch.equal(combined_rope[:, :, :, :16, :], rope_q)
+        assert torch.count_nonzero(combined_rope[0, :, :, 16:, :]) == 0
+        assert torch.equal(combined_rope[1, :, :, 16:, :], torch.ones_like(combined_rope[1, :, :, 16:, :]))
+
 
 class TestGenerateMasks:
     """Test generate_masks function."""

--- a/tests/test_jepa.py
+++ b/tests/test_jepa.py
@@ -9,7 +9,11 @@ from vit import ViTConfig
 
 from mjepa.jepa import (
     COSINE_JEPA_LOSS_KIND,
+    CROSS_ATTENTION_PREDICTOR_MODE,
+    DECODER_PREDICTOR_MODE,
+    ENCODER_PREDICTOR_MODE,
     MSE_JEPA_LOSS_KIND,
+    PREDICTOR_ATTENTION_MODES,
     PREDICTOR_PROJ_INIT_STD,
     CrossAttentionPredictor,
     JEPAConfig,
@@ -133,6 +137,7 @@ class TestJEPAConfig:
         assert config.scale == 4
         assert config.momentum == 0.99
         assert config.predictor_depth == 4
+        assert config.predictor_attention_mode == CROSS_ATTENTION_PREDICTOR_MODE
         assert config.disable_predictor_regularizers is False
         assert config.teacher_dtype is None
         assert config.use_gram_anchoring is False
@@ -147,6 +152,7 @@ class TestJEPAConfig:
             scale=8,
             momentum=0.95,
             predictor_depth=6,
+            predictor_attention_mode=DECODER_PREDICTOR_MODE,
             disable_predictor_regularizers=True,
             teacher_dtype=torch.bfloat16,
             stem_jepa_loss_weight=0.5,
@@ -157,6 +163,7 @@ class TestJEPAConfig:
         assert config.scale == 8
         assert config.momentum == 0.95
         assert config.predictor_depth == 6
+        assert config.predictor_attention_mode == DECODER_PREDICTOR_MODE
         assert config.disable_predictor_regularizers is True
         assert config.teacher_dtype == torch.bfloat16
         assert config.stem_jepa_loss_weight == 0.5
@@ -193,6 +200,7 @@ class TestYAMLConfig:
             "scale": 16,
             "momentum": 0.98,
             "predictor_depth": 8,
+            "predictor_attention_mode": ENCODER_PREDICTOR_MODE,
             "disable_predictor_regularizers": True,
             "teacher_dtype": "bfloat16",
             "use_gram_anchoring": True,
@@ -213,6 +221,7 @@ class TestYAMLConfig:
         assert config.scale == 16
         assert config.momentum == 0.98
         assert config.predictor_depth == 8
+        assert config.predictor_attention_mode == ENCODER_PREDICTOR_MODE
         assert config.disable_predictor_regularizers is True
         assert config.teacher_dtype == torch.bfloat16
         assert config.use_gram_anchoring is True
@@ -236,6 +245,7 @@ class TestYAMLConfig:
         scale: 12
         momentum: 0.97
         predictor_depth: 5
+        predictor_attention_mode: decoder
         disable_predictor_regularizers: true
         teacher_dtype: bfloat16
         use_gram_anchoring: true
@@ -255,6 +265,7 @@ class TestYAMLConfig:
         assert config.scale == 12
         assert config.momentum == 0.97
         assert config.predictor_depth == 5
+        assert config.predictor_attention_mode == DECODER_PREDICTOR_MODE
         assert config.disable_predictor_regularizers is True
         assert config.teacher_dtype == torch.bfloat16
         assert config.use_gram_anchoring is True
@@ -276,6 +287,11 @@ class TestYAMLConfig:
         """Test invalid stem JEPA loss weight."""
         with pytest.raises(ValueError, match="stem_jepa_loss_weight"):
             JEPAConfig(stem_jepa_loss_weight=-0.1)
+
+    def test_invalid_predictor_attention_mode(self):
+        """Test invalid predictor attention mode."""
+        with pytest.raises(ValueError, match="predictor_attention_mode must be one of"):
+            JEPAConfig(predictor_attention_mode=cast(Any, "seq2seq"))
 
 
 class TestComputeSigREGLoss:
@@ -412,9 +428,24 @@ class TestCrossAttentionPredictor:
         for block in predictor.blocks:
             block = cast(Any, block)
             assert block.drop_path_rate == pytest.approx(drop_path_rate)
-            assert block.cross_attention.dropout.p == pytest.approx(hidden_dropout)
-            assert block.cross_attention.attention_dropout.p == pytest.approx(attention_dropout)
+            checked_attention = False
+            for attention_name in ("self_attention", "cross_attention"):
+                attention = getattr(block, attention_name, None)
+                if attention is None:
+                    continue
+                checked_attention = True
+                assert attention.dropout.p == pytest.approx(hidden_dropout)
+                assert attention.attention_dropout.p == pytest.approx(attention_dropout)
+            assert checked_attention
             assert block.mlp.dropout.p == pytest.approx(hidden_dropout)
+
+    @pytest.mark.parametrize("attention_mode", PREDICTOR_ATTENTION_MODES)
+    def test_predictor_initialization_records_attention_mode(self, attention_mode):
+        """Test predictor exposes the configured attention mode."""
+        backbone = self._instantiate_backbone(torch.float32)
+        predictor = CrossAttentionPredictor(backbone, depth=2, attention_mode=attention_mode)
+
+        assert predictor.attention_mode == attention_mode
 
     @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
     def test_predictor_initialization_cpu_dtype(self, dtype):
@@ -488,7 +519,8 @@ class TestCrossAttentionPredictor:
         expected_out_dim = out_dim if out_dim is not None else hidden_size
         assert predictor.predictor_proj.out_features == expected_out_dim
 
-    def test_predictor_regularizers_follow_backbone_by_default(self):
+    @pytest.mark.parametrize("attention_mode", PREDICTOR_ATTENTION_MODES)
+    def test_predictor_regularizers_follow_backbone_by_default(self, attention_mode):
         """Test predictor regularizer values are inherited from the backbone by default."""
         hidden_dropout = 0.2
         attention_dropout = 0.3
@@ -498,11 +530,17 @@ class TestCrossAttentionPredictor:
             attention_dropout=attention_dropout,
             drop_path_rate=drop_path_rate,
         )
-        predictor = CrossAttentionPredictor(backbone, depth=2, disable_predictor_regularizers=False)
+        predictor = CrossAttentionPredictor(
+            backbone,
+            depth=2,
+            disable_predictor_regularizers=False,
+            attention_mode=attention_mode,
+        )
 
         self._assert_predictor_regularizers(predictor, hidden_dropout, attention_dropout, drop_path_rate)
 
-    def test_predictor_regularizers_can_be_disabled(self):
+    @pytest.mark.parametrize("attention_mode", PREDICTOR_ATTENTION_MODES)
+    def test_predictor_regularizers_can_be_disabled(self, attention_mode):
         """Test predictor regularizers are set to zero when override is enabled."""
         hidden_dropout = 0.2
         attention_dropout = 0.3
@@ -512,11 +550,17 @@ class TestCrossAttentionPredictor:
             attention_dropout=attention_dropout,
             drop_path_rate=drop_path_rate,
         )
-        predictor = CrossAttentionPredictor(backbone, depth=2, disable_predictor_regularizers=True)
+        predictor = CrossAttentionPredictor(
+            backbone,
+            depth=2,
+            disable_predictor_regularizers=True,
+            attention_mode=attention_mode,
+        )
 
         self._assert_predictor_regularizers(predictor, 0.0, 0.0, 0.0)
 
-    def test_predictor_positional_device_arg_is_backwards_compatible(self):
+    @pytest.mark.parametrize("attention_mode", PREDICTOR_ATTENTION_MODES)
+    def test_predictor_positional_device_arg_is_backwards_compatible(self, attention_mode):
         """Test positional device argument does not toggle regularizer override."""
         hidden_dropout = 0.2
         attention_dropout = 0.3
@@ -528,11 +572,12 @@ class TestCrossAttentionPredictor:
         )
         device = torch.device("cpu")
 
-        predictor = CrossAttentionPredictor(backbone, 2, None, device)
+        predictor = CrossAttentionPredictor(backbone, 2, None, device, attention_mode=attention_mode)
 
         self._assert_predictor_regularizers(predictor, hidden_dropout, attention_dropout, drop_path_rate)
 
-    def test_predictor_forward_promotes_output_to_float32(self):
+    @pytest.mark.parametrize("attention_mode", PREDICTOR_ATTENTION_MODES)
+    def test_predictor_forward_promotes_output_to_float32(self, attention_mode):
         """Test predictor outputs are promoted to float32."""
         vit_config = ViTConfig(
             in_channels=3,
@@ -548,7 +593,7 @@ class TestCrossAttentionPredictor:
             dtype=torch.bfloat16,
         )
         backbone = vit_config.instantiate()
-        predictor = CrossAttentionPredictor(backbone, depth=2)
+        predictor = CrossAttentionPredictor(backbone, depth=2, attention_mode=attention_mode)
         context = torch.randn(2, 32, 64, dtype=torch.bfloat16)
         context_mask = torch.zeros(2, 64, dtype=torch.bool)
         context_mask[:, :32] = True
@@ -559,10 +604,11 @@ class TestCrossAttentionPredictor:
 
         assert output.dtype == torch.float32
 
-    def test_predictor_forward_heads_disable_outer_autocast_for_fp32_projections(self):
+    @pytest.mark.parametrize("attention_mode", PREDICTOR_ATTENTION_MODES)
+    def test_predictor_forward_heads_disable_outer_autocast_for_fp32_projections(self, attention_mode):
         """Test projection heads do not inherit a lower-precision outer autocast context."""
         backbone = self._instantiate_backbone(torch.float32)
-        predictor = CrossAttentionPredictor(backbone, depth=2)
+        predictor = CrossAttentionPredictor(backbone, depth=2, attention_mode=attention_mode)
         predictor.enable_shallow_head()
 
         context = torch.randn(2, 32, 64)
@@ -585,10 +631,11 @@ class TestCrossAttentionPredictor:
 
         assert autocast_enabled == [False]
 
-    def test_predictor_can_enable_and_emit_shallow_head(self):
+    @pytest.mark.parametrize("attention_mode", PREDICTOR_ATTENTION_MODES)
+    def test_predictor_can_enable_and_emit_shallow_head(self, attention_mode):
         """Test predictor can emit both deep and shallow targets from the shared trunk."""
         backbone = self._instantiate_backbone(torch.float32)
-        predictor = CrossAttentionPredictor(backbone, depth=2)
+        predictor = CrossAttentionPredictor(backbone, depth=2, attention_mode=attention_mode)
         predictor.enable_shallow_head()
 
         context = torch.randn(2, 32, 64)
@@ -603,6 +650,20 @@ class TestCrossAttentionPredictor:
         assert shallow_output is not None
         assert shallow_output.dtype == torch.float32
         assert shallow_output.shape == deep_output.shape
+
+    def test_encoder_mode_supports_context_free_cls_pass(self):
+        """Test encoder mode can process CLS-conditioned predictor calls without a context mask."""
+        backbone = self._instantiate_backbone(torch.float32)
+        predictor = CrossAttentionPredictor(backbone, depth=2, attention_mode=ENCODER_PREDICTOR_MODE)
+
+        cls_context = torch.randn(2, 4, 64)
+        target_mask = torch.zeros(2, 64, dtype=torch.bool)
+        target_mask[:, 32:48] = True
+
+        output = predictor((8, 8), cls_context, None, target_mask)
+
+        assert output.shape == (2, 16, 64)
+        assert output.dtype == torch.float32
 
 
 class TestGenerateMasks:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3,7 +3,16 @@ import torch
 import torch.nn.functional as F
 from vit import ViT, ViTConfig, ViTFeatures
 
-from mjepa.jepa import COSINE_JEPA_LOSS_KIND, MSE_JEPA_LOSS_KIND, CrossAttentionPredictor, JEPAConfig, JEPALossKind
+from mjepa.jepa import (
+    COSINE_JEPA_LOSS_KIND,
+    CROSS_ATTENTION_PREDICTOR_MODE,
+    MSE_JEPA_LOSS_KIND,
+    PREDICTOR_ATTENTION_MODES,
+    CrossAttentionPredictor,
+    JEPAConfig,
+    JEPALossKind,
+    PredictorAttentionMode,
+)
 from mjepa.model import MJEPA, MJEPALosses, MJEPAPredictions
 
 
@@ -45,13 +54,19 @@ def _make_test_model(
     num_cls_tokens: int,
     sigreg_loss_weight: float,
     jepa_loss_kind: JEPALossKind = MSE_JEPA_LOSS_KIND,
+    predictor_attention_mode: PredictorAttentionMode = CROSS_ATTENTION_PREDICTOR_MODE,
 ) -> MJEPA:
     config = _make_jepa_config(
         sigreg_loss_weight=sigreg_loss_weight,
         jepa_loss_kind=jepa_loss_kind,
+        predictor_attention_mode=predictor_attention_mode,
     )
     backbone = _make_test_vit_config(num_cls_tokens=num_cls_tokens).instantiate()
-    predictor = CrossAttentionPredictor(backbone, depth=TEST_PREDICTOR_DEPTH)
+    predictor = CrossAttentionPredictor(
+        backbone,
+        depth=TEST_PREDICTOR_DEPTH,
+        attention_mode=config.predictor_attention_mode,
+    )
     return MJEPA(config, backbone, predictor, autocast_dtype=torch.float32)
 
 
@@ -69,6 +84,7 @@ def _make_jepa_config(**overrides: object) -> JEPAConfig:
         "scale": 2,
         "momentum": 0.98,
         "predictor_depth": 2,
+        "predictor_attention_mode": CROSS_ATTENTION_PREDICTOR_MODE,
         "scheduled": False,
         "use_gram_anchoring": False,
         "stem_jepa_loss_weight": 0.0,
@@ -382,6 +398,14 @@ class TestMJEPAInitialization:
 
         assert model.predictor.predictor_proj_shallow is not None
 
+    def test_initialization_rejects_predictor_attention_mode_mismatch(self, small_vit: ViT):
+        """Test that config and predictor attention modes must agree."""
+        config = JEPAConfig(predictor_attention_mode="decoder")
+        predictor = CrossAttentionPredictor(small_vit, depth=2, attention_mode=CROSS_ATTENTION_PREDICTOR_MODE)
+
+        with pytest.raises(ValueError, match="Predictor attention mode does not match JEPAConfig"):
+            MJEPA(config, small_vit, predictor, autocast_dtype=torch.float32)
+
     def test_teacher_frozen(self, mjepa_model):
         """Test that teacher parameters are frozen."""
         for param in mjepa_model.teacher.parameters():
@@ -458,6 +482,26 @@ class TestMJEPAForwardPasses:
 
         assert isinstance(output, torch.Tensor)
         assert output.shape[0] == 2
+        assert output.dtype == torch.float32
+
+    @pytest.mark.parametrize("attention_mode", PREDICTOR_ATTENTION_MODES)
+    def test_forward_predictor_supports_all_attention_modes(self, attention_mode):
+        """Test direct predictor forwards across attention modes."""
+        model = _make_test_model(
+            num_cls_tokens=TEST_NUM_CLS_TOKENS,
+            sigreg_loss_weight=0.0,
+            predictor_attention_mode=attention_mode,
+        )
+        tokenized_size = (8, 8)
+        context = torch.randn(2, 32, 64)
+        context_mask = torch.zeros(2, 64, dtype=torch.bool)
+        context_mask[:, :32] = True
+        target_mask = torch.zeros(2, 64, dtype=torch.bool)
+        target_mask[:, 32:48] = True
+
+        output = model.forward_predictor(tokenized_size, context, context_mask, target_mask)
+
+        assert output.shape == (2, TEST_TARGET_TOKENS, TEST_HIDDEN_SIZE)
         assert output.dtype == torch.float32
 
     def test_forward_probe(self, mjepa_model: MJEPA, dummy_vit_features):
@@ -1195,6 +1239,24 @@ class TestMJEPAForward:
         assert predictions.pred_with_cls is None
         assert predictions.pred.shape[0] == dummy_batch.shape[0]
         assert predictions.student_output.num_cls_tokens == 0
+
+    @pytest.mark.parametrize("attention_mode", PREDICTOR_ATTENTION_MODES)
+    def test_forward_supports_all_attention_modes(self, dummy_batch, attention_mode):
+        """Test the full MJEPA forward path across predictor attention modes."""
+        model = _make_test_model(
+            num_cls_tokens=TEST_NUM_CLS_TOKENS,
+            sigreg_loss_weight=0.0,
+            predictor_attention_mode=attention_mode,
+        )
+        model.eval()
+
+        with torch.no_grad():
+            predictions = model(dummy_batch, jepa_scale=2, epoch=0)
+
+        assert predictions.pred.shape == (TEST_BATCH_SIZE, TEST_TARGET_TOKENS, TEST_HIDDEN_SIZE)
+        assert predictions.pred.dtype == torch.float32
+        assert predictions.pred_with_cls is not None
+        assert predictions.pred_with_cls.shape == predictions.pred.shape
 
     def test_get_probe_tokens_falls_back_to_visual_tokens_without_cls(
         self, mjepa_model_no_gram: MJEPA, dummy_vit_features: ViTFeatures

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -12,7 +12,7 @@ from torch.optim import AdamW
 from torch.optim.lr_scheduler import LinearLR
 from vit import ViTConfig
 
-from mjepa.jepa import CrossAttentionPredictor
+from mjepa.jepa import CROSS_ATTENTION_PREDICTOR_MODE, DECODER_PREDICTOR_MODE, CrossAttentionPredictor
 from mjepa.trainer import (
     ResolutionConfig,
     TrainerConfig,
@@ -624,6 +624,47 @@ class TestPredictorCheckpointCompatibility:
             resume_scheduler = LinearLR(resume_optimizer, start_factor=0.1, end_factor=1.0, total_iters=100)
 
             with pytest.raises(ValueError, match="mode='fresh'"):
+                load_checkpoint(
+                    path,
+                    backbone=resume_backbone,
+                    predictor=resume_predictor,
+                    teacher=resume_teacher,
+                    optimizer=resume_optimizer,
+                    scheduler=resume_scheduler,
+                    mode="resume",
+                )
+
+    def test_resume_rejects_mismatched_attention_mode(self, vit_config):
+        backbone = vit_config.instantiate()
+        predictor = CrossAttentionPredictor(backbone, depth=2, attention_mode=CROSS_ATTENTION_PREDICTOR_MODE)
+        teacher = vit_config.instantiate()
+        optimizer = AdamW(backbone.parameters(), lr=1e-3)
+        scheduler = LinearLR(optimizer, start_factor=0.1, end_factor=1.0, total_iters=100)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "checkpoint.pt"
+            save_checkpoint(
+                path,
+                backbone=backbone,
+                predictor=predictor,
+                teacher=teacher,
+                optimizer=optimizer,
+                scheduler=scheduler,
+                step=1,
+                epoch=1,
+            )
+
+            resume_backbone = vit_config.instantiate()
+            resume_predictor = CrossAttentionPredictor(
+                resume_backbone,
+                depth=2,
+                attention_mode=DECODER_PREDICTOR_MODE,
+            )
+            resume_teacher = vit_config.instantiate()
+            resume_optimizer = AdamW(resume_backbone.parameters(), lr=1e-3)
+            resume_scheduler = LinearLR(resume_optimizer, start_factor=0.1, end_factor=1.0, total_iters=100)
+
+            with pytest.raises(ValueError, match="predictor attention-mode changes"):
                 load_checkpoint(
                     path,
                     backbone=resume_backbone,


### PR DESCRIPTION
## Motivation
The predictor was hard-wired to cross-attention, which made it impossible to compare alternative predictor architectures without changing code. This adds a config-level switch so training can keep the current behavior by default while allowing decoder-style and encoder-style predictor variants.

## Solution
Add a typed `JEPAConfig` option for predictor attention mode and wire `CrossAttentionPredictor` to build and execute the matching block type. Keep the public predictor API unchanged, validate config/predictor consistency, and reject checkpoint resume attempts when the saved predictor mode does not match the current one.

## Changes
- add `predictor_attention_mode` to `JEPAConfig`, export the new type, and document the default `cross_attention` setting in `config.yaml`
- update `CrossAttentionPredictor` to support `cross_attention`, `decoder`, and `encoder` modes while preserving existing output shapes and shallow-head behavior
- handle encoder-mode combined-sequence execution for both visual-token and CLS-token predictor passes
- add explicit model and checkpoint validation so mismatched predictor modes fail fast with clear errors
- expand predictor, model, and trainer tests to cover all three modes, encoder CLS-context execution, YAML/config validation, and resume mismatch handling

## Test plan
Ran the repository quality and test targets on the final branch state.
- [x] `make quality`
- [x] `make types`
- [x] `make test`

## Test suite changes
- [x] No unit tests were removed.
- [x] No existing unit tests were materially altered.
- [x] Added targeted coverage for predictor attention-mode configuration, predictor execution across all modes, and checkpoint resume validation for mode mismatches.

Generated with Codex.